### PR TITLE
Added alternate scenario

### DIFF
--- a/PubSubTest.Tests/OrleansPubSubTests.cs
+++ b/PubSubTest.Tests/OrleansPubSubTests.cs
@@ -16,13 +16,13 @@ namespace PubSubTest.Tests
             public void Configure(ISiloBuilder siloBuilder)
             {
                 siloBuilder.AddPubSub();
-                siloBuilder.AddStartupTask<Silo>();
+                siloBuilder.AddStartupTask<SiloStartupTask>();
             }
         }
 
         public OrleansPubSubTests()
         {
-            Silo.Clear();
+            SiloStartupTask.Clear();
         }
 
         [Fact]
@@ -82,9 +82,9 @@ namespace PubSubTest.Tests
         {
             var message = Guid.NewGuid().ToString();
 
-            await Silo.All.First().PubSub.PublishAsync(message);
+            await SiloStartupTask.All.First().PubSub.PublishAsync(message);
 
-            Assert.Equal(expectedCount, Silo.All.Count(x => x.Received.Contains(message)));
+            Assert.Equal(expectedCount, SiloStartupTask.All.Count(x => x.Received.Contains(message)));
         }
 
         private async Task<bool> WaitForClusterSizeAsync(TestCluster cluster, int expectedSize)

--- a/PubSubTest.Tests/OrleansSimpleStreamingPubSubTests.cs
+++ b/PubSubTest.Tests/OrleansSimpleStreamingPubSubTests.cs
@@ -1,0 +1,126 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using Orleans.Hosting;
+using Orleans.Runtime;
+using Orleans.TestingHost;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PubSubTest.Tests
+{
+    public sealed class OrleansSimpleStreamingPubSubTests : IAsyncLifetime
+    {
+        public OrleansSimpleStreamingPubSubTests()
+        {
+            TestContext.ServiceProviders.Value = new ConcurrentDictionary<IServiceProvider, bool>();
+
+            _key = Guid.NewGuid().ToString();
+            _cluster = new TestClusterBuilder(3)
+                    .AddSiloBuilderConfigurator<SiloConfigurator>()
+                    .Build();
+        }
+
+        private readonly string _key;
+        private readonly TestCluster _cluster;
+
+        public async Task InitializeAsync()
+        {
+            await _cluster.DeployAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            await _cluster.DisposeAsync();
+        }
+
+        [Fact]
+        public async Task Should_receive_pubsub_message()
+        {
+            await PublishAsync(3, _key);
+        }
+
+        [Fact]
+        public async Task Should_not_send_message_to_dead_member()
+        {
+            await _cluster.StopSiloAsync(_cluster.Silos[1]);
+            await PublishAsync(2, _key);
+        }
+
+        [Fact]
+        public async Task Should_not_send_message_to_dead_but_not_unregistered_member()
+        {
+            await _cluster.KillSiloAsync(_cluster.Silos[1]);
+            await PublishAsync(2, _key);
+        }
+
+        [Fact]
+        public async Task Should_send_message_to_new_member()
+        {
+            await _cluster.StartAdditionalSiloAsync();
+            await PublishAsync(4, _key);
+        }
+
+        private async Task PublishAsync(int expectedCount, string key)
+        {
+            var message = Guid.NewGuid().ToString();
+
+            // wake up each local replica
+            foreach (var provider in TestContext.ServiceProviders.Value.Keys)
+            {
+                var silo = provider.GetRequiredService<Silo>();
+                await provider.GetRequiredService<IGrainFactory>().GetSimpleStreamingReplicaGrain(silo.SiloAddress, key).GetAsync();
+            }
+
+            // push the message
+            await TestContext.ServiceProviders.Value.Keys.First()
+                .GetRequiredService<IGrainFactory>()
+                .GetStreamingPublisherGrain(key)
+                .SendAsync(message);
+
+            // get the propagated message
+            var actual = 0;
+            foreach (var provider in TestContext.ServiceProviders.Value.Keys)
+            {
+                var silo = provider.GetRequiredService<Silo>();
+                var result = await provider.GetRequiredService<IGrainFactory>().GetSimpleStreamingReplicaGrain(silo.SiloAddress, key).GetAsync();
+                actual += result == message ? 1 : 0;
+            }
+
+            Assert.Equal(expectedCount, actual);
+        }
+    }
+
+    public static class TestContext
+    {
+        public static AsyncLocal<ConcurrentDictionary<IServiceProvider, bool>> ServiceProviders { get; } = new AsyncLocal<ConcurrentDictionary<IServiceProvider, bool>>();
+    }
+
+    public class SiloConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder siloBuilder)
+        {
+            siloBuilder.AddSimpleMessageStreamProvider("SMS2");
+            siloBuilder.AddMemoryGrainStorageAsDefault();
+            siloBuilder.AddMemoryGrainStorage("PubSubStore");
+            siloBuilder.AddStartupTask((provider, token) =>
+            {
+                // expose the silo service providers to the running test
+                if (TestContext.ServiceProviders != null)
+                {
+                    TestContext.ServiceProviders.Value.TryAdd(provider, true);
+
+                    provider.GetRequiredService<Silo>().SiloTerminated.ContinueWith(x =>
+                    {
+                        TestContext.ServiceProviders.Value.TryRemove(provider, out _);
+                    });
+                }
+
+                return Task.CompletedTask;
+            });
+        }
+    }
+}

--- a/PubSubTest.Tests/OrleansStreamingPubSubTests.cs
+++ b/PubSubTest.Tests/OrleansStreamingPubSubTests.cs
@@ -18,13 +18,13 @@ namespace PubSubTest.Tests
             public void Configure(ISiloBuilder siloBuilder)
             {
                 siloBuilder.AddPubSub();
-                siloBuilder.AddStartupTask<Silo>();
+                siloBuilder.AddStartupTask<SiloStartupTask>();
             }
         }
 
         public OrleansStreamingPubSubTests()
         {
-            Silo.Clear();
+            SiloStartupTask.Clear();
         }
 
         [Fact]
@@ -101,9 +101,9 @@ namespace PubSubTest.Tests
         {
             var message = Guid.NewGuid().ToString();
 
-            await Silo.All.First().PubSub.PublishAsync(message);
+            await SiloStartupTask.All.First().PubSub.PublishAsync(message);
 
-            Assert.Equal(expectedCount, Silo.All.Count(x => x.Received.Contains(message)));
+            Assert.Equal(expectedCount, SiloStartupTask.All.Count(x => x.Received.Contains(message)));
         }
 
         private async Task<bool> WaitForClusterSizeAsync(TestCluster cluster, int expectedSize)

--- a/PubSubTest.Tests/SiloStartupTask.cs
+++ b/PubSubTest.Tests/SiloStartupTask.cs
@@ -6,18 +6,18 @@ using System.Threading.Tasks;
 
 namespace PubSubTest.Tests
 {
-    public sealed class Silo : IStartupTask, IDisposable
+    public sealed class SiloStartupTask : IStartupTask, IDisposable
     {
-        private static readonly List<Silo> allSilos = new List<Silo>();
+        private static readonly List<SiloStartupTask> allSilos = new List<SiloStartupTask>();
         private readonly HashSet<string> received = new HashSet<string>();
 
         public IPubSub PubSub { get; }
 
-        public static IReadOnlyCollection<Silo> All => allSilos;
+        public static IReadOnlyCollection<SiloStartupTask> All => allSilos;
 
         public IReadOnlyCollection<string> Received => received;
 
-        public Silo(IPubSub pubSub)
+        public SiloStartupTask(IPubSub pubSub)
         {
             PubSub = pubSub;
         }

--- a/PubSubTest/PubSubTest.csproj
+++ b/PubSubTest/PubSubTest.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.3.0" />
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.3.0" />
     <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="3.3.0" />
+    <PackageReference Include="protobuf-net" Version="3.0.52" />
   </ItemGroup>
 
 </Project>

--- a/PubSubTest/SimpleOrleansStreams/ISimpleStreamingPublisherGrain.cs
+++ b/PubSubTest/SimpleOrleansStreams/ISimpleStreamingPublisherGrain.cs
@@ -1,0 +1,32 @@
+﻿using Orleans;
+using PubSubTest.SimpleOrleansStreams;
+using System;
+using System.Threading.Tasks;
+
+namespace PubSubTest.SimpleOrleansStreams
+{
+    public interface ISimpleStreamingPublisherGrain : IGrainWithStringKey
+    {
+        public ValueTask<string> GetAsync();
+
+        public Task SendAsync(string payload);
+    }
+}
+
+namespace Orleans
+{
+    /// <summary>
+    /// Discoverability extensions for <see cref="ISimpleStreamingPublisherGrain"/>.
+    /// </summary>
+    public static class SimpleStreamingPublisherGrainFactoryExtensions
+    {
+        public static ISimpleStreamingPublisherGrain GetStreamingPublisherGrain(this IGrainFactory factory, string key)
+        {
+            if (factory is null) throw new ArgumentNullException(nameof(key));
+
+            key = key.Trim().ToUpperInvariant();
+
+            return factory.GetGrain<ISimpleStreamingPublisherGrain>(key);
+        }
+    }
+}

--- a/PubSubTest/SimpleOrleansStreams/ISimpleStreamingReplicaGrain.cs
+++ b/PubSubTest/SimpleOrleansStreams/ISimpleStreamingReplicaGrain.cs
@@ -1,0 +1,55 @@
+﻿using Orleans;
+using Orleans.Runtime;
+using PubSubTest.SimpleOrleansStreams;
+using System;
+using System.Threading.Tasks;
+
+namespace PubSubTest.SimpleOrleansStreams
+{
+    public interface ISimpleStreamingReplicaGrain : IGrainWithStringKey
+    {
+        public ValueTask<string> GetAsync();
+    }
+}
+
+namespace Orleans
+{
+    /// <summary>
+    /// Discoverability extensions for <see cref="ISimpleStreamingReplicaGrain"/>.
+    /// </summary>
+    public static class SimpleStreamingReplicaGrainFactoryExtensions
+    {
+        /// <summary>
+        /// Gets the local replica grain. Use of this grain requires a co-hosted deployment (caller api and silo in the same process so the local <see cref="SiloAddress"/> is available.
+        /// </summary>
+        /// <param name="factory">The factory to use.</param>
+        /// <param name="address">This must be the local silo address.</param>
+        /// <param name="key">Sharding key of the data graph.</param>
+        public static ISimpleStreamingReplicaGrain GetSimpleStreamingReplicaGrain(this IGrainFactory factory, SiloAddress address, string key)
+        {
+            if (factory is null) throw new ArgumentNullException(nameof(key));
+
+            key = key.Trim().ToUpperInvariant();
+            var parsable = address.ToParsableString();
+
+            return factory.GetGrain<ISimpleStreamingReplicaGrain>($"{key}|{parsable}");
+        }
+    }
+
+    /// <summary>
+    /// Key extensions for <see cref="ISimpleStreamingReplicaGrain"/>.
+    /// </summary>
+    public static class SimpleStreamingReplicaGrainKeyExtensions
+    {
+        public static (string key, SiloAddress address) GetCompositeKey(this ISimpleStreamingReplicaGrain grain)
+        {
+            if (grain is null) throw new ArgumentNullException(nameof(grain));
+
+            var components = grain.GetPrimaryKeyString().Split('|');
+            var key = components[0];
+            var address = SiloAddress.FromParsableString(components[1]);
+
+            return (key, address);
+        }
+    }
+}

--- a/PubSubTest/SimpleOrleansStreams/MySimpleStreamingOptions.cs
+++ b/PubSubTest/SimpleOrleansStreams/MySimpleStreamingOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace PubSubTest.SimpleOrleansStreams
+{
+    public class MySimpleStreamingOptions
+    {
+        public string StreamProviderName { get; set; } = "SMS2";
+        public int RetryCount { get; set; } = 3;
+    }
+}

--- a/PubSubTest/SimpleOrleansStreams/OrleansStreamExtensions.cs
+++ b/PubSubTest/SimpleOrleansStreams/OrleansStreamExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Orleans.Streams
+{
+    public static class OrleansStreamExtensions
+    {
+        public static async Task<StreamSubscriptionHandle<T>> ResumeOrSubscribeAsync<T>(this IAsyncStream<T> stream, IAsyncObserver<T> observer)
+        {
+            if (stream is null) throw new ArgumentNullException(nameof(stream));
+
+            var handles = await stream.GetAllSubscriptionHandles();
+
+            // resume or subscribe to the stream
+            if (handles.Count > 0)
+            {
+                // resume the first subscription
+                var handle = await handles[0].ResumeAsync(observer);
+
+                // cleanup any accidental duplicates
+                for (var i = 1; i < handles.Count; ++i)
+                {
+                    await handles[i].UnsubscribeAsync();
+                }
+
+                return handle;
+            }
+            else
+            {
+                return await stream.SubscribeAsync(observer);
+            }
+        }
+
+        public static async Task UnsubscribeAllAsync<T>(this IAsyncStream<T> stream)
+        {
+            if (stream is null) throw new ArgumentNullException(nameof(stream));
+
+            var handles = await stream.GetAllSubscriptionHandles();
+
+            foreach (var handle in handles)
+            {
+                await handle.UnsubscribeAsync();
+            }
+        }
+    }
+}

--- a/PubSubTest/SimpleOrleansStreams/SimpleStreamingPublisherGrain.cs
+++ b/PubSubTest/SimpleOrleansStreams/SimpleStreamingPublisherGrain.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams;
+using ProtoBuf;
+using System;
+using System.Threading.Tasks;
+
+namespace PubSubTest.SimpleOrleansStreams
+{
+    public class SimpleStreamingPublisherGrain : Grain, ISimpleStreamingPublisherGrain
+    {
+        private readonly MySimpleStreamingOptions _options;
+        private readonly IPersistentState<SimpleStreamingPublisherGrainState> _state;
+
+        public SimpleStreamingPublisherGrain(IOptions<MySimpleStreamingOptions> options, [PersistentState("State")] IPersistentState<SimpleStreamingPublisherGrainState> state)
+        {
+            _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+            _state = state ?? throw new ArgumentNullException(nameof(state));
+        }
+
+        private IAsyncStream<string> _stream;
+
+        public override Task OnActivateAsync()
+        {
+            // keep the stream ref handy
+            var key = this.GetPrimaryKeyString();
+            _stream = GetStreamProvider(_options.StreamProviderName).GetStream<string>(Guid.Empty, key);
+
+            return base.OnActivateAsync();
+        }
+
+        public async Task SendAsync(string payload)
+        {
+            _state.State.Payload = payload;
+            await _state.WriteStateAsync();
+
+            for (var i = 0; i < _options.RetryCount; ++i)
+            {
+                try
+                {
+                    await _stream.OnNextAsync(payload);
+                    break;
+                }
+                catch
+                {
+                    if (i >= _options.RetryCount - 1)
+                    {
+                        throw;
+                    }
+                }
+            }
+        }
+
+        public ValueTask<string> GetAsync() => new ValueTask<string>(_state.State.Payload);
+    }
+
+    [ProtoContract]
+    public class SimpleStreamingPublisherGrainState
+    {
+        [ProtoMember(1)]
+        public string Payload { get; set; }
+    }
+}

--- a/PubSubTest/SimpleOrleansStreams/SimpleStreamingReplicaGrain.cs
+++ b/PubSubTest/SimpleOrleansStreams/SimpleStreamingReplicaGrain.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.Placement;
+using Orleans.Runtime;
+using Orleans.Streams;
+using System;
+using System.Threading.Tasks;
+
+namespace PubSubTest.SimpleOrleansStreams
+{
+    [PreferLocalPlacement]
+    public class SimpleStreamingReplicaGrain : Grain, ISimpleStreamingReplicaGrain, IAsyncObserver<string>
+    {
+        private readonly Silo _silo;
+        private readonly MySimpleStreamingOptions _options;
+
+        public SimpleStreamingReplicaGrain(Silo silo, IOptions<MySimpleStreamingOptions> options)
+        {
+            _silo = silo ?? throw new ArgumentNullException(nameof(silo));
+            _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        private string _payload;
+        private StreamSubscriptionHandle<string> _handle;
+
+        public override async Task OnActivateAsync()
+        {
+            await base.OnActivateAsync();
+
+            var (key, address) = this.GetCompositeKey();
+            var stream = GetStreamProvider(_options.StreamProviderName).GetStream<string>(Guid.Empty, key);
+
+            // the most common activation will happen in the local silo of the query call
+            _handle = await stream.ResumeOrSubscribeAsync(this);
+
+            // however if this activation is induced by the streaming provider (e.g. after a silo crash) then it will activate in the wrong silo
+            // in that case we want to gracefully discard this replica
+            if (address != _silo.SiloAddress)
+            {
+                DeactivateOnIdle();
+            }
+        }
+
+        public override async Task OnDeactivateAsync()
+        {
+            await _handle.UnsubscribeAsync();
+
+            await base.OnDeactivateAsync();
+        }
+
+        public ValueTask<string> GetAsync() => new ValueTask<string>(_payload);
+
+        public Task OnNextAsync(string item, StreamSequenceToken token = null)
+        {
+            _payload = item;
+
+            return Task.CompletedTask;
+        }
+
+        public Task OnCompletedAsync() => Task.CompletedTask;
+
+        public Task OnErrorAsync(Exception ex) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
I have added a new scenario. This is based on yours but without a custom placement director or other outside lifetime manipulation points. These components tend to be brittle and prone to timing bugs so I tend to avoid them until necessary. The new scenario requires a co-hosted deployment to work. There's a similar set of tests for it.